### PR TITLE
fullfill #19 support compute unit price in query

### DIFF
--- a/apiService.go
+++ b/apiService.go
@@ -14,6 +14,8 @@ func APIService(c ClustersToRun) {
 		router := gin.Default()
 		router.GET("/:cluster/latest", getLatest)
 		router.GET("/:cluster/last6hours", timeout.New(timeout.WithTimeout(10*time.Second), timeout.WithHandler(last6hours)))
+		router.GET("/:cluster/last6hours/nocomputeprice", timeout.New(timeout.WithTimeout(10*time.Second), timeout.WithHandler(last6hoursNoPrice)))
+		router.GET("/:cluster/last6hours/all", timeout.New(timeout.WithTimeout(10*time.Second), timeout.WithHandler(last6hoursAll)))
 		router.GET("/health", health)
 		router.GET("/:cluster/rpc", getRPCEndpoint)
 		if mode == HTTPS {
@@ -158,11 +160,45 @@ func last6hours(c *gin.Context) {
 	var ret []DataPoint1MinResultJSON
 	switch cluster {
 	case "mainnet-beta":
-		ret = GetLast6hours(MainnetBeta)
+		ret = GetLast6hours(MainnetBeta, HasComputeUnitPrice, 0)
 	case "testnet":
-		ret = GetLast6hours(Testnet)
+		ret = GetLast6hours(Testnet, HasComputeUnitPrice, 0)
 	case "devnet":
-		ret = GetLast6hours(Devnet)
+		ret = GetLast6hours(Devnet, HasComputeUnitPrice, 0)
+	default:
+		c.AbortWithStatus(http.StatusNotFound)
+		return
+	}
+	c.IndentedJSON(http.StatusOK, ret)
+}
+
+func last6hoursNoPrice(c *gin.Context) {
+	cluster := c.Param("cluster")
+	var ret []DataPoint1MinResultJSON
+	switch cluster {
+	case "mainnet-beta":
+		ret = GetLast6hours(MainnetBeta, NoComputeUnitPrice, 0)
+	case "testnet":
+		ret = GetLast6hours(Testnet, NoComputeUnitPrice, 0)
+	case "devnet":
+		ret = GetLast6hours(Devnet, NoComputeUnitPrice, 0)
+	default:
+		c.AbortWithStatus(http.StatusNotFound)
+		return
+	}
+	c.IndentedJSON(http.StatusOK, ret)
+}
+
+func last6hoursAll(c *gin.Context) {
+	cluster := c.Param("cluster")
+	var ret []DataPoint1MinResultJSON
+	switch cluster {
+	case "mainnet-beta":
+		ret = GetLast6hours(MainnetBeta, AllData, 0)
+	case "testnet":
+		ret = GetLast6hours(Testnet, AllData, 0)
+	case "devnet":
+		ret = GetLast6hours(Devnet, AllData, 0)
 	default:
 		c.AbortWithStatus(http.StatusNotFound)
 		return
@@ -172,7 +208,7 @@ func last6hours(c *gin.Context) {
 
 // GetLatestResult return the latest DataPoint1Min PingResult from the cluster and convert it into PingResultJSON
 func GetLatestResult(c Cluster) DataPoint1MinResultJSON {
-	records := getLastN(c, DataPoint1Min, 1)
+	records := getLastN(c, DataPoint1Min, 1, HasComputeUnitPrice, 0)
 	if len(records) > 0 {
 		return To1MinWindowJson(&records[0])
 	}
@@ -180,17 +216,32 @@ func GetLatestResult(c Cluster) DataPoint1MinResultJSON {
 	return DataPoint1MinResultJSON{}
 }
 
-// GetLatestResult return the latest 6hr DataPoint1Min PingResult from the cluster and convert it into PingResultJSON
-func GetLast6hours(c Cluster) []DataPoint1MinResultJSON {
-	lastRecord := getLastN(c, DataPoint1Min, 1)
+// GetLast6hours return the latest 6hr DataPoint1Min PingResult from the cluster and convert it into PingResultJSON
+func GetLast6hours(c Cluster, priceType ComputeUnitPriceType, threshold uint64) []DataPoint1MinResultJSON {
+	lastRecord := getLastN(c, DataPoint1Min, 1, priceType, 0)
 	now := time.Now().UTC().Unix()
 	if len(lastRecord) > 0 {
-		now = lastRecord[0].TimeStamp
+		if (now - lastRecord[0].TimeStamp) < 60 { // in past one min, there is a record, use it
+			now = lastRecord[0].TimeStamp
+		}
 	}
 
 	// (-1) because getAfter function return only after .
 	beginOfPast60Hours := now - 6*60*60
-	records := getAfter(c, DataPoint1Min, beginOfPast60Hours)
+	var records []PingResult
+	switch priceType {
+	case NoComputeUnitPrice:
+		records = getAfter(c, DataPoint1Min, beginOfPast60Hours, NoComputeUnitPrice, 0)
+	case HasComputeUnitPrice:
+		records = getAfter(c, DataPoint1Min, beginOfPast60Hours, HasComputeUnitPrice, 0)
+	case ComputeUnitPriceThreshold:
+		records = getAfter(c, DataPoint1Min, beginOfPast60Hours, ComputeUnitPriceThreshold, threshold)
+	case AllData:
+		fallthrough
+	default:
+		records = getAfter(c, DataPoint1Min, beginOfPast60Hours, AllData, 0)
+	}
+
 	if len(records) == 0 {
 		return []DataPoint1MinResultJSON{}
 	}
@@ -206,6 +257,7 @@ func GetLast6hours(c Cluster) []DataPoint1MinResultJSON {
 	}
 	return ret
 }
+
 func GetClusterConfig(c Cluster) ClusterConfig {
 	switch c {
 	case MainnetBeta:

--- a/workers.go
+++ b/workers.go
@@ -149,7 +149,7 @@ func reportWorker(cConf ClusterConfig) {
 			lastReporTime = now - int64(cConf.Report.Interval)
 			log.Println("reconstruct lastReport time=", lastReporTime, "time now=", time.Now().UTC().Unix())
 		}
-		data := getAfter(cConf.Cluster, DataPoint1Min, lastReporTime)
+		data := getAfter(cConf.Cluster, DataPoint1Min, lastReporTime, HasComputeUnitPrice, 0)
 		if len(data) <= 0 { // No Data
 			log.Println(cConf.Cluster, " getAfter return empty")
 			time.Sleep(30 * time.Second)


### PR DESCRIPTION
Support compute unit price query in database so that front-end can fetch data according to compute price type. 
The new API is as below,
/:cluster/last6hours 
    return data which compute_unit_price >  0 
/:cluster/last6hours/nocomputeprice 
    return data which compute_unit_price = 0
/:cluster/last6hours/all 
    return all data