### PR TITLE
Dual mode send seperate alert fullfill #33

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -4,9 +4,13 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"strings"
 )
 
+const AlertTriggerNameLength = 30
+
 type AlertTrigger struct {
+	Name            string
 	LastLoss        float64
 	CurrentLoss     float64
 	ThresholdIndex  int
@@ -17,6 +21,7 @@ type AlertTrigger struct {
 
 func NewAlertTrigger(conf ClusterConfig) AlertTrigger {
 	s := AlertTrigger{}
+	s.Name = "default"
 	s.FilePath = conf.Report.LevelFilePath
 	s.CurrentLoss = 0
 	s.LastLoss = 0
@@ -24,8 +29,18 @@ func NewAlertTrigger(conf ClusterConfig) AlertTrigger {
 	s.ThresholdIndex = s.ReadIndexFromFile()
 	return s
 }
-func NewAlertTriggerByParams(levelFilePath string, lossThreshold float64) AlertTrigger {
+func NewAlertTriggerByParams(alertName string, levelFilePath string, lossThreshold float64) AlertTrigger {
 	s := AlertTrigger{}
+	alertName = strings.Trim(alertName, " ")
+	if len(alertName) > AlertTriggerNameLength {
+		log.Panic("alertName length > ", AlertTriggerNameLength)
+	}
+	if len(alertName) == 0 {
+		s.Name = "default"
+	} else {
+		s.Name = alertName
+	}
+
 	s.FilePath = levelFilePath
 	s.CurrentLoss = 0
 	s.LastLoss = 0
@@ -58,7 +73,7 @@ func (s *AlertTrigger) UpThresholdIndex(loss float64) int {
 func (s *AlertTrigger) WritIndexToFile(level int) {
 	if s.FilePath != "" {
 		os.WriteFile(s.FilePath, []byte(strconv.Itoa(level)), 0777)
-		log.Println("WriteLevelToFile : ", strconv.Itoa(level), " to ", s.FilePath)
+		log.Println(s.Name, " trigger ", "WriteLevelToFile : ", strconv.Itoa(level), " to ", s.FilePath)
 	}
 }
 
@@ -72,7 +87,7 @@ func (s *AlertTrigger) ReadIndexFromFile() int {
 		if err != nil {
 			return 0
 		}
-		log.Println("ReadFromFile : ", level, " from ", s.FilePath)
+		log.Println(s.Name, " trigger ", "ReadFromFile : ", level, " from ", s.FilePath)
 		return level
 	}
 	return 0
@@ -86,7 +101,7 @@ func (s *AlertTrigger) ShouldAlertSend() bool {
 	if s.CurrentLoss < s.ThresholdLevels[0] {
 		s.ThresholdIndex = 0
 		s.WritIndexToFile(0)
-		log.Println("Loss = ", s.CurrentLoss, " < ", s.ThresholdLevels[0], "Index:", s.ThresholdIndex)
+		log.Println(s.Name, " trigger ", "Loss = ", s.CurrentLoss, " < ", s.ThresholdLevels[0], "Index:", s.ThresholdIndex)
 		return false
 	}
 	// adjust threshold up, include index = 0
@@ -94,7 +109,7 @@ func (s *AlertTrigger) ShouldAlertSend() bool {
 		s.ThresholdIndex = s.UpThresholdIndex(s.CurrentLoss)
 		s.ThresholdAsc = true
 		s.WritIndexToFile(s.ThresholdIndex)
-		log.Println("ThresholdLevel Up To :", s.ThresholdIndex, " Loss:", s.CurrentLoss, " ShouldSend", true)
+		log.Println(s.Name, " trigger ", "ThresholdLevel Up To :", s.ThresholdIndex, " Loss:", s.CurrentLoss, " ShouldSend", true)
 		return true
 	}
 	// adjust threshold down, index = 0 does not need to down level
@@ -102,9 +117,9 @@ func (s *AlertTrigger) ShouldAlertSend() bool {
 		s.ThresholdIndex = s.UpThresholdIndex(s.CurrentLoss)
 		s.ThresholdAsc = false
 		s.WritIndexToFile(s.ThresholdIndex)
-		log.Println("ThresholdLevel Down To :", s.ThresholdIndex, " Loss:", s.CurrentLoss, " ShouldSend", true)
+		log.Println(s.Name, " trigger ", "ThresholdLevel Down To :", s.ThresholdIndex, " Loss:", s.CurrentLoss, " ShouldSend", true)
 		return true
 	}
-	log.Println("ThresholdLevel NOT change. Loss:", s.CurrentLoss, "Index:", s.ThresholdIndex)
+	log.Println(s.Name, " trigger ", "ThresholdLevel NOT change. Loss:", s.CurrentLoss, "Index:", s.ThresholdIndex)
 	return false
 }

--- a/alert.go
+++ b/alert.go
@@ -24,7 +24,15 @@ func NewAlertTrigger(conf ClusterConfig) AlertTrigger {
 	s.ThresholdIndex = s.ReadIndexFromFile()
 	return s
 }
-
+func NewAlertTriggerByParams(levelFilePath string, lossThreshold float64) AlertTrigger {
+	s := AlertTrigger{}
+	s.FilePath = levelFilePath
+	s.CurrentLoss = 0
+	s.LastLoss = 0
+	s.ThresholdLevels = []float64{lossThreshold, float64(50), float64(75), float64(100)}
+	s.ThresholdIndex = s.ReadIndexFromFile()
+	return s
+}
 func (s *AlertTrigger) Update(currentLoss float64) {
 	s.LastLoss = s.CurrentLoss
 	s.CurrentLoss = currentLoss * 100

--- a/config-testnet.yaml.sample
+++ b/config-testnet.yaml.sample
@@ -34,7 +34,6 @@ PingConfig:
  WaitConfirmationTimeout: 75
  StatusCheckInterval: 1
  MinPerPingTime: 10
- ComputeFeeDualMode: true
  ComputeFeeDualMode: false   # send tx both with and without compute fee
  RequestUnits: 200000        # change RequestUnits 
  ComputeUnitPrice: 1000      # change ComputeUnitPrice

--- a/output.go
+++ b/output.go
@@ -81,12 +81,13 @@ func PingResultToJson(stat *PingSatistic) DataPoint1MinResultJSON {
 }
 
 // ReportPayload get the report within specified minutes
-func (s *SlackPayload) ReportPayload(c Cluster, data *GroupsAllStatistic, globalSatistic GlobalStatistic, hideKeywords []string) {
+func (s *SlackPayload) ReportPayload(c Cluster, data *GroupsAllStatistic, globalSatistic GlobalStatistic, hideKeywords []string, messageMemo string) {
 	// Header Block
-	headerText := fmt.Sprintf("total-submitted: %3.0f, total-confirmed:%3.0f, average-loss:%3.1f%s",
+	headerText := fmt.Sprintf("total-submitted: %3.0f, total-confirmed:%3.0f, average-loss:%3.1f%s\n memo:%s",
 		globalSatistic.Submitted,
 		globalSatistic.Confirmed,
-		globalSatistic.Loss*100, "%")
+		globalSatistic.Loss*100, "%",
+		messageMemo)
 	header := Block{
 		BlockType: "section",
 		BlockText: SlackText{
@@ -109,7 +110,7 @@ func (s *SlackPayload) ReportPayload(c Cluster, data *GroupsAllStatistic, global
 	s.Blocks = append(s.Blocks, body)
 }
 
-func (s *SlackPayload) AlertPayload(conf ClusterConfig, gStat *GlobalStatistic, errorStistic map[string]int, thresholdAdj float64, hideKeywords []string) {
+func (s *SlackPayload) AlertPayload(conf ClusterConfig, gStat *GlobalStatistic, errorStistic map[string]int, thresholdAdj float64, hideKeywords []string, messageMemo string) {
 	var text, timeStatis string
 	if gStat.TimeStatistic.Stddev <= 0 {
 		timeStatis = fmt.Sprintf(" %d/%3.0f/%d/%s ", gStat.TimeStatistic.Min, gStat.TimeStatistic.Mean, gStat.TimeStatistic.Max, "NaN")
@@ -126,8 +127,8 @@ func (s *SlackPayload) AlertPayload(conf ClusterConfig, gStat *GlobalStatistic, 
 		errsorStatis = strings.ReplaceAll(errsorStatis, w, "")
 	}
 
-	text = fmt.Sprintf("{ hostname: %s, submitted: %3.0f, confirmed:%3.0f, loss: %3.1f%s, confirmation: min/mean/max/stddev = %s, next_threshold:%3.0f%s, error: %s}",
-		conf.HostName, gStat.Submitted, gStat.Confirmed, gStat.Loss*100, "%", timeStatis, thresholdAdj, "%", errsorStatis)
+	text = fmt.Sprintf("{ hostname: %s, memo: %s ,submitted: %3.0f, confirmed:%3.0f, loss: %3.1f%s, confirmation: min/mean/max/stddev = %s, next_threshold:%3.0f%s, error: %s}",
+		conf.HostName, messageMemo, gStat.Submitted, gStat.Confirmed, gStat.Loss*100, "%", timeStatis, thresholdAdj, "%", errsorStatis)
 
 	header := Block{
 		BlockType: "section",
@@ -172,11 +173,12 @@ func reportRecordBlock(data *GroupsAllStatistic) string {
 }
 
 // ReportPayload get the report within specified minutes
-func (s *DiscordPayload) ReportPayload(c Cluster, data *GroupsAllStatistic, globalSatistic GlobalStatistic, hideKeywords []string) {
-	summary := fmt.Sprintf("**total-submitted: %3.0f  total-confirmed: %3.0f average-loss: %3.1f%s**",
+func (s *DiscordPayload) ReportPayload(c Cluster, data *GroupsAllStatistic, globalSatistic GlobalStatistic, hideKeywords []string, messageMemo string) {
+	summary := fmt.Sprintf("**total-submitted: %3.0f  total-confirmed: %3.0f average-loss: %3.1f%s**\nmemo: %s",
 		globalSatistic.Submitted,
 		globalSatistic.Confirmed,
-		globalSatistic.Loss*100, "%")
+		globalSatistic.Loss*100, "%",
+		messageMemo)
 	header := "( Submitted, Confirmed, Loss, min/mean/max/stddev ms )"
 	records := reportRecordBlock(data)
 	memo := "*BlockhashNotFound do not count as a transaction\n"
@@ -185,7 +187,7 @@ func (s *DiscordPayload) ReportPayload(c Cluster, data *GroupsAllStatistic, glob
 }
 
 // AlertPayload get the report within specified minutes
-func (s *DiscordPayload) AlertPayload(conf ClusterConfig, gStat *GlobalStatistic, errorStistic map[string]int, thresholdAdj float64, hideKeywords []string) {
+func (s *DiscordPayload) AlertPayload(conf ClusterConfig, gStat *GlobalStatistic, errorStistic map[string]int, thresholdAdj float64, hideKeywords []string, messageMemo string) {
 	var timeStatis string
 	if gStat.TimeStatistic.Stddev <= 0 {
 		timeStatis = fmt.Sprintf(" %d/%3.0f/%d/%s ", gStat.TimeStatistic.Min, gStat.TimeStatistic.Mean, gStat.TimeStatistic.Max, "NaN")
@@ -202,8 +204,8 @@ func (s *DiscordPayload) AlertPayload(conf ClusterConfig, gStat *GlobalStatistic
 		errsorStatis = strings.ReplaceAll(errsorStatis, w, "")
 	}
 
-	text := fmt.Sprintf("```{ hostname: %s, submitted: %3.0f, confirmed:%3.0f, loss: %3.1f%s, confirmation: min/mean/max/stddev = %s, next_threshold:%3.0f%s, error: %s}```",
-		conf.HostName, gStat.Submitted, gStat.Confirmed, gStat.Loss*100, "%", timeStatis, thresholdAdj, "%", errsorStatis)
+	text := fmt.Sprintf("```{ hostname: %s, memo: %s, submitted: %3.0f, confirmed:%3.0f, loss: %3.1f%s, confirmation: min/mean/max/stddev = %s, next_threshold:%3.0f%s, error: %s}```",
+		conf.HostName, messageMemo, gStat.Submitted, gStat.Confirmed, gStat.Loss*100, "%", timeStatis, thresholdAdj, "%", errsorStatis)
 	s.Content = text
 }
 

--- a/rpcPing.go
+++ b/rpcPing.go
@@ -10,6 +10,8 @@ import (
 	"github.com/portto/solana-go-sdk/types"
 )
 
+const WaitConfirmationTxTimeout = 10
+
 // TakeTime a struct to record a serious of start and end time. Start and End is used for current record and Times is for store take-time
 type TakeTime struct {
 	Times []int64
@@ -68,7 +70,7 @@ func Ping(c *client.Client, pType PingType, acct types.Account, config ClusterCo
 
 		waitErr := waitConfirmation(c, hash,
 			time.Duration(config.WaitConfirmationTimeout)*time.Second,
-			time.Duration(config.TxTimeout)*time.Second,
+			time.Duration(WaitConfirmationTxTimeout)*time.Second,
 			time.Duration(config.StatusCheckInterval)*time.Millisecond)
 		timer.TimerStop()
 		if !waitErr.NoError() {


### PR DESCRIPTION
ComputeFeeDualMode = true send transaction with fee and no-fee. 
To distinguish alerts, we add a no-fee alert when ComputeFeeDualMode is on.
The logic is , 
when ComputeUnitPrice >0  &  RequestUnits > 0 &  ComputeFeeDualMode = true, 
ping-result with ComputeUnitPrice=0 will be fetch and an alert will be sent if reach the critieria.