### PR TITLE
use GetLatestBlockhash instead of GetRecentBlockhash

### DIFF
--- a/Transfer.go
+++ b/Transfer.go
@@ -23,8 +23,9 @@ var (
 
 func Transfer(c *client.Client, sender types.Account, feePayer types.Account, receiverPubkey string, txTimeout time.Duration) (txHash string, pingErr PingResultError) {
 	// to fetch recent blockhash
-	res, err := c.GetRecentBlockhash(context.Background())
+	res, err := c.GetLatestBlockhash(context.Background())
 	if err != nil {
+		log.Println("Failed to get latest blockhash, err: ", err)
 		return "", PingResultError(fmt.Sprintf("Failed to get latest blockhash, err: %v", err))
 	}
 	// create a message

--- a/influxdb.go
+++ b/influxdb.go
@@ -61,7 +61,6 @@ func (i *InfluxdbClient) SendDatapointAsync(p *influxdb2write.Point) {
 	}
 	go func() {
 		writeAPI := i.Client.WriteAPIBlocking(i.Organization, i.Bucket)
-		log.Println("InfluxBucket", i.Bucket)
 		err := writeAPI.WritePoint(context.Background(), p)
 		if err != nil {
 			log.Println("Influxdb write point ERROR! ", err)


### PR DESCRIPTION
Cause:
getRecentBlockhash
DEPRECATED
This method is expected to be removed in solana-core v2.0 Please use [getLatestBlockhash](https://docs.solana.com/api/http#getlatestblockhash) instead
Solution: 
Use getLatestBlockhash